### PR TITLE
added 'decoding' of output image

### DIFF
--- a/Computer Vision/05_Style_Transfer.ipynb
+++ b/Computer Vision/05_Style_Transfer.ipynb
@@ -1459,7 +1459,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Much better!"
+    "Much better! But the colours seem 'off', because the output activations had not been 'decoded' with the reverse-tfms before being shown as an image, so we will do that below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dec_res = dl.decode_batch(tuplify(res))[0][0]\n",
+    "dec_res.show();"
    ]
   },
   {


### PR DESCRIPTION
Hi,

I added a couple of lines to 'decode' the output image, before showing it. This should fix the slightly 'off' colours seen (even though the colour-changes can be seen as a 'feature' instead of a bug! =P )

I did not re-run your notebook to generate the actual decoded image to be shown, so that I can minimise the git-diff changes. Please feel free to update and show the decoded image in the notebook if you want.

Thanks.

Yijin