### PR TITLE
Fix RetinaNet inference typo

### DIFF
--- a/Computer Vision/imports/utils.py
+++ b/Computer Vision/imports/utils.py
@@ -18,7 +18,7 @@ def activ_to_bbox(acts, anchors, flatten=True):
     if flatten:
         acts.mul_(acts.new_tensor([[0.1, 0.1, 0.2, 0.2]])) #Can't remember where those scales come from, but they help regularize
         centers = anchors[...,2:] * acts[...,:2] + anchors[...,:2]
-        sizes = anchors[...,2:] * torch.exp(acts[...,:2])
+        sizes = anchors[...,2:] * torch.exp(acts[...,2:])
         return torch.cat([centers, sizes], -1)
     else: return [activ_to_bbox(act,anc) for act,anc in zip(acts, anchors)]
     return res


### PR DESCRIPTION
Pretty sure these are the 'height/width' activations. Seems to be using the center x/y activations instead.

Also note - the bbox_to_activ tries to call activ_to_bbox if `flatten=False`. I assume that line should be changed to something like

```
else: return [bbox_to_activ(bbox,anc) for bbox,anc in zip(bboxes, anchors)]
```

This also applies to `metrics.py` where the same code is copy/pasted. The above activation error is there too, but `activ_to_bbox` is never called in `metrics.py` (well, the incorrect `flatten=false` codepath pretends to call it), so it's not a major issue unless someone is copying from the file as reference.